### PR TITLE
Add `admin_name` and `code` inputs to the admin shipping methods form.

### DIFF
--- a/admin/app/views/spree/admin/shipping_methods/form/_display.html.erb
+++ b/admin/app/views/spree/admin/shipping_methods/form/_display.html.erb
@@ -21,5 +21,27 @@
         </div>
       </div>
     </div>
+
+    <div class="row">
+      <div class="col-lg-6">
+        <div class="form-group">
+          <%= f.label :admin_name, Spree.t(:internal_name) %>
+          <%= f.text_field :admin_name, class: 'form-control' %>
+          <%= f.error_message_on :admin_name %>
+        </div>
+
+        <p class="form-text text-muted small mt-2">
+          This will be displayed to admins.
+        </p>
+      </div>
+
+      <div class="col-lg-6">
+        <div class="form-group">
+          <%= f.label :code, Spree.t(:code) %>
+          <%= f.text_field :code, class: 'form-control' %>
+          <%= f.error_message_on :code %>
+        </div>
+      </div>
+    </div>
   </div>
 </div>

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -205,7 +205,7 @@ module Spree
 
     @@shipping_category_attributes = [:name]
 
-    @@shipping_method_attributes = [:name, :code,:tracking_url, :tax_category_id, :display_on,
+    @@shipping_method_attributes = [:name, :admin_name, :code, :tracking_url, :tax_category_id, :display_on,
                                     :estimated_transit_business_days_min, :estimated_transit_business_days_max,
                                     :calculator_type, :preferences, zone_ids: [], shipping_category_ids: [], calculator_attributes: {}]
 


### PR DESCRIPTION
- Add `admin_name` to permitted attributes