### PR TITLE
Add enabled preference to announcement bar

### DIFF
--- a/admin/app/views/spree/admin/page_sections/forms/_announcement_bar.html.erb
+++ b/admin/app/views/spree/admin/page_sections/forms/_announcement_bar.html.erb
@@ -3,3 +3,8 @@
     action: 'trix-change->auto-submit#submit'
   }, class: 'mb-3' %>
 </div>
+
+<div class="form-group">
+  <%= f.label :preferred_enabled, Spree.t('enabled') %>
+  <%= f.select :preferred_enabled, options_for_select([[ Spree.t('say_yes'), "true" ], [ Spree.t('say_no'), "false" ]], @page_section.preferred_enabled), {}, data: { action: 'auto-submit#submit' }, class: "custom-select" %>
+</div>

--- a/core/app/models/spree/page_sections/announcement_bar.rb
+++ b/core/app/models/spree/page_sections/announcement_bar.rb
@@ -10,6 +10,8 @@ module Spree
       BOTTOM_PADDING_DEFAULT = 8
       TOP_BORDER_WIDTH_DEFAULT = 0
 
+      preference :enabled, :boolean, default: true
+
       def self.role
         'header'
       end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -978,6 +978,7 @@ en:
     empty: Empty
     empty_cart: Empty Cart
     enable_mail_delivery: Enable Mail Delivery
+    enabled: Enabled
     end: End
     ending_at: Ending at
     ending_in: Ending in

--- a/storefront/app/views/themes/default/spree/page_sections/_announcement_bar.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_announcement_bar.html.erb
@@ -1,5 +1,5 @@
 <% cache_unless page_builder_enabled?, spree_base_cache_scope.call(section) do %>
-  <% if section.present? && section.text.body.to_plain_text.present? %>
+  <% if section.present? && section.preferred_enabled && section.text.body.to_plain_text.present? %>
     <div
       class='w-full justify-center items-center flex announcement-bar'
       style='<%= section_styles(section) %>'


### PR DESCRIPTION
- Introduced a boolean `enabled` preference with a default of `true`.
- Updated the admin form to include a toggle for the enabled state.
- Adjusted storefront view to respect the `enabled` preference.
- Added the `enabled` translation to `en.yml`.