### PR TITLE
Use store default locale in edit translation view

### DIFF
--- a/admin/app/views/spree/admin/translations/edit.html.erb
+++ b/admin/app/views/spree/admin/translations/edit.html.erb
@@ -18,7 +18,7 @@
         <thead>
           <tr>
             <th scope="col" class="text-center"><%= Spree.t(:field) %></th>
-            <th scope="col" class="text-center" style="width: 40%;"><%= Spree.t('i18n.this_file_language', locale: :en) %> (<%= Spree.t(:default) %>)</th>
+            <th scope="col" class="text-center" style="width: 40%;"><%= Spree.t('i18n.this_file_language', locale: @default_locale) %> (<%= Spree.t(:default) %>)</th>
             <th scope="col" class="text-center"><%= Spree.t('i18n.this_file_language', locale: @selected_translation_locale) %></th>
           </tr>
         </thead>


### PR DESCRIPTION
- Replaced hardcoded :en with dynamic @default_locale.
- Ensures view reflects the store’s configured default language.